### PR TITLE
chore: update config-file path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please see [GitHub's documentation](https://docs.github.com/en/code-security/sup
 Specifically, for our default list, you will be including the following:
 
 ```
-config-file: 'github/amazon-ospo/dependency-review-config/default/dependency-review-config.yml@main'
+config-file: amazon-ospo/dependency-review-config/default/dependency-review-config.yml@main
 ```
 
 ## Security


### PR DESCRIPTION
### Issue #, if available:
n/a

### Description of changes:

Removes `github/` prefix from the `config-file` path in the `README` example demonstrating how to add the default list.

#### Why?
It appears the GitHub documentation on [using a configuration file from an external repository](https://github.com/actions/dependency-review-action/blob/main/docs/examples.md#using-a-configuration-file-from-an-external-repository) is incorrect, or at least confusing.

> Let's say that the configuration file is located in github/octorepo/dependency-review-config.yml@main
The Dependancy Review Action workflow file will then look like this:
// ...
with:
     config-file: 'github/octorepo/dependency-review-config.yml@main'

:x: failing with `github/` prefix and single quotes. [[reference](https://github.com/aws-amplify/amplify-swift/actions/runs/6253346539/job/16978546010)]
```
Run actions/dependency-review-action@7d90b4f05fea31dde1c4a1fb3fa787e197ea93ab
  with:
    config-file: github/amazon-ospo/dependency-review-config/default/dependency-review-config.yml@main
    repo-token: ***
Error: Unable to fetch or parse config file: Error fetching remote config file
```

✅  passing without `github/` prefix and single quotes. [[reference](https://github.com/aws-amplify/amplify-swift/actions/runs/6253370592/job/16978627915)]
```
Run actions/dependency-review-action@7d90b4f05fea31dde1c4a1fb3fa787e197ea93ab
  with:
    config-file: amazon-ospo/dependency-review-config/default/dependency-review-config.yml@main
    repo-token: ***
Dependency review did not detect any denied packages
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
