### PR TITLE
chore: Allow Licenses include Ruby in dependency-review-config.yml

### DIFF
--- a/default/dependency-review-config.yml
+++ b/default/dependency-review-config.yml
@@ -18,6 +18,7 @@ allow-licenses:
   - PDDL-1.0
   - PostgreSQL
   - Python-2.0
+  - Ruby
   - Spencer-94
   - Unicode-DFS-2015
   - Unicode-DFS-2016


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We use this file for dependency license review. It failed with the following:
```
The following dependencies have incompatible licenses:
  Gemfile.lock » json@2.7.2 – License: Ruby OR (BSD-2-Clause AND Ruby)
  Error: Dependency review detected incompatible licenses.
```

The PR that introduced the dependency change is in https://github.com/aws-amplify/amplify-swift/pull/3810

The ask here is if we can include **Ruby** in the `allow-licenses`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
